### PR TITLE
Use clojure.spec.alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+## Unreleased
+
+### Changes
+
+- Update orchestra to use `clojure.spec.alpha`. Only specs registered by `clojure.spec.alpha` will be instrumented. Also added a dependency on `[org.clojure/spec.alpha "0.1.94"]`. See this [mailing list post](https://groups.google.com/forum/#!msg/clojure/10dbF7w2IQo/ec37TzP5AQAJ) for more details on the change. [#2](https://github.com/jeaye/orchestra/issues/2)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/jeaye/orchestra.svg?branch=master)](https://travis-ci.org/jeaye/orchestra) [![codecov](https://codecov.io/gh/jeaye/orchestra/branch/master/graph/badge.svg)](https://codecov.io/gh/jeaye/orchestra) [![Clojars Project](https://img.shields.io/clojars/v/orchestra.svg)](https://clojars.org/orchestra)
 # Orchestra : complete instrumentation for clojure.spec
 Orchestra is a Clojure library made as a drop-in replacement for
-[clojure.spec.test](https://clojure.org/guides/spec), which provides custom
+[clojure.spec.test.alpha](https://clojure.org/guides/spec), which provides custom
 instrumentation that validates all aspects of function specs. By default,
 clojure.spec will only instrument `:args`.  This leaves out `:ret` and `:fn`
 from automatic validation; Orchestra checks all of them for you.
@@ -15,12 +15,12 @@ Leiningen dependency:
 ```
 
 Just replace your `ns` and `require` forms to reference `orchestra.spec.test`
-instead of `clojure.spec.test`. No further code changes required!
+instead of `clojure.spec.test.alpha`. No further code changes required!
 
 ```clojure
 ;; Before
 (ns kitty-ninja
-  (:require [clojure.spec.test :as st]))
+  (:require [clojure.spec.test.alpha :as st]))
 
 ;; After
 (ns kitty-ninja

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "https://github.com/jeaye/orchestra"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha15"]]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
+                 [org.clojure/spec.alpha "0.1.94"]]
   :plugins [[lein-cloverage "1.0.9"]]
   :global-vars {*warn-on-reflection* true}
   :profiles {:uberjar {:aot :all}})

--- a/src/orchestra/spec/test.clj
+++ b/src/orchestra/spec/test.clj
@@ -10,8 +10,8 @@
   (:refer-clojure :exclude [test])
   (:require
    [clojure.pprint :as pp]
-   [clojure.spec :as s]
-   [clojure.spec.gen :as gen]
+   [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as gen]
    [clojure.string :as str]))
 
 (defn ->sym

--- a/test/orchestra/core_test.clj
+++ b/test/orchestra/core_test.clj
@@ -1,6 +1,6 @@
 (ns orchestra.core-test
   (:require [clojure.test :refer :all]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [orchestra.spec.test :refer :all]))
 
 (defn instrument-fixture [f]


### PR DESCRIPTION
I wasn't sure about updating orchestra's namespace to `orchestra.spec.test.alpha`, happy to change that too if you'd like?

- Update orchestra to use clojure.spec.alpha
- Update README to reference spec alpha
- Update Clojure to 1.9.0-alpha16
- Add [org.clojure/spec.alpha "0.1.94"]
- Add changelog entry