### PR TITLE
Var data

### DIFF
--- a/src/clj/orchestra/spec/test.clj
+++ b/src/clj/orchestra/spec/test.clj
@@ -115,7 +115,7 @@ failure in instrument."
                                        (#'s/->sym v)
                                        " did not conform to spec:\n"
                                        (with-out-str (s/explain-out ed)))
-                                    (assoc ed :var v))))
+                                    (assoc ed :orchestra.spec/var v))))
                          conformed))))]
     (fn
       [& args]

--- a/src/clj/orchestra/spec/test.clj
+++ b/src/clj/orchestra/spec/test.clj
@@ -115,7 +115,7 @@ failure in instrument."
                                        (#'s/->sym v)
                                        " did not conform to spec:\n"
                                        (with-out-str (s/explain-out ed)))
-                                    ed)))
+                                    (assoc ed :var v))))
                          conformed))))]
     (fn
       [& args]


### PR DESCRIPTION
Attaching a `:orchestra.spec/var` key to the ex-info thrown by instrument. This is helpful for handling the exception with further tooling, such as REPL middleware. In principle the var could be recovered from the exception's message string, but that seems comparatively messy.