### PR TITLE
Conform :ret into :fn

### DIFF
--- a/src/clj/orchestra/spec/test.cljc
+++ b/src/clj/orchestra/spec/test.cljc
@@ -130,7 +130,7 @@ failure in instrument."
           (when-let [spec (:fn fn-spec)]
             (if (nil? cargs)
               (throw (no-args-spec v fn-spec))
-              (conform! v :fn spec {:ret cret :args cargs} ::s/fn)))
+              (conform! v :fn spec {:ret (or cret ret) :args cargs} ::s/fn)))
           ret)
         (.applyTo ^clojure.lang.IFn f args)))))
 

--- a/src/clj/orchestra/spec/test.cljc
+++ b/src/clj/orchestra/spec/test.cljc
@@ -124,13 +124,13 @@ failure in instrument."
       (if *instrument-enabled*
         (let [cargs (when-let [spec (:args fn-spec)]
                       (conform! v :args spec args ::s/args))
-              ret (.applyTo ^clojure.lang.IFn f args)]
-          (when-let [spec (:ret fn-spec)]
-            (conform! v :ret spec ret ::s/ret))
+              ret (.applyTo ^clojure.lang.IFn f args)
+              cret (when-let [spec (:ret fn-spec)]
+                     (conform! v :ret spec ret ::s/ret))]
           (when-let [spec (:fn fn-spec)]
             (if (nil? cargs)
               (throw (no-args-spec v fn-spec))
-              (conform! v :fn spec {:ret ret :args cargs} ::s/fn)))
+              (conform! v :fn spec {:ret cret :args cargs} ::s/fn)))
           ret)
         (.applyTo ^clojure.lang.IFn f args)))))
 

--- a/src/cljs/orchestra_cljs/spec/test.cljs
+++ b/src/cljs/orchestra_cljs/spec/test.cljs
@@ -127,7 +127,7 @@
                     (when-let [spec (:fn fn-spec)]
                       (if (nil? cargs)
                         (throw (no-args-spec v fn-spec))
-                        (conform! v :fn spec {:ret cret :args cargs} ::s/fn)))
+                        (conform! v :fn spec {:ret (or cret ret) :args cargs} ::s/fn)))
                     ret))
                 (apply' f args)))]
     (when-not pure-variadic?

--- a/src/cljs/orchestra_cljs/spec/test.cljs
+++ b/src/cljs/orchestra_cljs/spec/test.cljs
@@ -121,13 +121,13 @@
                   (let [cargs (when (:args fn-spec)
                                 (conform! v :args (:args fn-spec) args ::s/args))
                         ret (binding [*instrument-enabled* true]
-                              (apply' f args))]
-                    (when (:ret fn-spec)
-                      (conform! v :ret (:ret fn-spec) ret ::s/ret))
+                              (apply' f args))
+                        cret (when (:ret fn-spec)
+                               (conform! v :ret (:ret fn-spec) ret ::s/ret))]
                     (when-let [spec (:fn fn-spec)]
                       (if (nil? cargs)
                         (throw (no-args-spec v fn-spec))
-                        (conform! v :fn spec {:ret ret :args cargs} ::s/fn)))
+                        (conform! v :fn spec {:ret cret :args cargs} ::s/fn)))
                     ret))
                 (apply' f args)))]
     (when-not pure-variadic?

--- a/test/cljc/orchestra/core_test.cljc
+++ b/test/cljc/orchestra/core_test.cljc
@@ -192,3 +192,15 @@
   (st/instrument)
   (f))
 (use-fixtures :each instrument-fixture)
+
+(defn-spec conform-ret-into-fn (s/or :error #{:error}
+                                     :success string?)
+  {:fn #(condp = (-> % :ret key)
+          :success (and (clojure.string/starts-with? (-> % :ret val) "your-")
+                        (clojure.string/ends-with? (-> % :ret val) (-> % :args :string)))
+          true)}
+  [string string?]
+  (str "your-" string))
+
+(deftest conform-ret-into-fn-test
+  (is (conform-ret-into-fn "Hello")))


### PR DESCRIPTION
Fixes #26 

Some notes:

The spec docs says to ignore `:fn` in the case where either `:args` or `:ret` is missing, but Orchestra has opted to treat a missing `:args` as a failure. I initially intended to treat a missing `:ret` the same way, but was unable to write a failing test for it... It seems that even without specifying a `:ret` spec, the `:ret` spec is set to something anyway. I tried:

```
(defn func-no-ret-spec [meow]
  (Math/abs meow))
(s/fdef func-no-ret-spec
  :args (s/cat :meow number?)
  :fn (constantly true))

(deftest func-no-ret-spec-test
  (is (thrown? #?(:clj RuntimeException :cljs :default)
               (func-no-ret-spec -42))))
```

But this did not fail as expected. Inspecting the code `(:ret spec)` was set even though I didn't provide one. I don't know the Orchestra implementation well enough to deduct why.