### PR TITLE
automatically call `instrument` upon every function definition

### DIFF
--- a/src/cljc/orchestra/detail.cljc
+++ b/src/cljc/orchestra/detail.cljc
@@ -1,7 +1,8 @@
 (ns orchestra.detail
-  (:require [#?(:clj clojure.spec.alpha
-                :cljs cljs.spec.alpha)
-             :as s]))
+  (:require
+    [#?(:clj  clojure.spec.alpha
+        :cljs cljs.spec.alpha) :as s]
+    [orchestra.spec.test :as ost]))
 
 ;;;; destructure
 
@@ -176,8 +177,8 @@
                        {:args args-spec})}))
 
 (defn defn-spec-helper [& args]
-  (let [s-fdef (spec-fn ::fdef)
-        exploded (apply explode-def args)
+  (let [s-fdef        (spec-fn ::fdef)
+        exploded      (apply explode-def args)
         stripped-meta (dissoc (:meta exploded) :fn)]
     `(do
        (defn ~(::name exploded)
@@ -185,6 +186,7 @@
          ~(or stripped-meta {})
          ~@(::arities exploded))
        (~s-fdef ~(::name exploded)
-                :args ~(-> exploded ::spec-map :args)
-                :fn ~(-> exploded ::spec-map :fn)
-                :ret ~(-> exploded ::spec-map :ret)))))
+         :args ~(-> exploded ::spec-map :args)
+         :fn ~(-> exploded ::spec-map :fn)
+         :ret ~(-> exploded ::spec-map :ret))
+       (ost/instrument))))


### PR DESCRIPTION
Hi - We need a way to automatically call `instrument` after a function is defined.  It is too error-prone to ask the user to include `(st/instrument)` at the bottom of each source-code file.

This way works, but I am open to suggestions for other implementations.

Of course, it may be best to put this variation in another NS, perhaps `orchestra.auto` or something.

Alan
