### PR TITLE
Preserve metadata in defn-spec

### DIFF
--- a/src/cljc/orchestra/detail.cljc
+++ b/src/cljc/orchestra/detail.cljc
@@ -170,6 +170,7 @@
         args-spec (build-args-spec conformed-arities exploded-arities)]
     {::name (:name conformed)
      ::doc (:docstring conformed)
+     ::meta (:meta conformed)
      ::arities (map render-arity exploded-arities)
      ::spec-map (merge (select-keys (:meta conformed) [:fn])
                        (select-keys conformed [:ret])
@@ -178,7 +179,7 @@
 (defn defn-spec-helper [& args]
   (let [s-fdef (spec-fn ::fdef)
         exploded (apply explode-def args)
-        stripped-meta (dissoc (:meta exploded) :fn)]
+        stripped-meta (dissoc (::meta exploded) :fn)]
     `(do
        (defn ~(::name exploded)
          ~(or (::doc exploded) "")

--- a/test/cljc/orchestra/core_test.cljc
+++ b/test/cljc/orchestra/core_test.cljc
@@ -83,7 +83,20 @@
     (is (= "Doc strings also work just fine."
            (-> #'doc-string' meta :doc)))))
 
-; Blocked on a ClojureScript bug for now
+(defn-spec metadata' nil?
+  "Docstring"
+  {:test-meta true}
+  []
+  nil)
+
+(deftest metadata
+  (testing "Invocation"
+    (is (nil? (metadata'))))
+  (testing "Preserves metadata"
+    (is (:test-meta (meta #'metadata')))
+    (is (= "Docstring" (-> #'metadata' meta :doc)))))
+
+                                        ; Blocked on a ClojureScript bug for now
 (defn-spec arities' number?
   ([a number?]
    (inc a))


### PR DESCRIPTION
previously, the metadata would be parsed but discarded